### PR TITLE
fix: resolve Symbol's definition is void : org-make-tag-matcher

### DIFF
--- a/dotemacs.org
+++ b/dotemacs.org
@@ -1066,6 +1066,7 @@ This provide the ~my/org-imenu-filter~ that allow to filter sidebar entries usin
 
 #+begin_src emacs-lisp
 
+(require 'org)
 (require 'svg-tag-mode)
 
 (defvar my/org-imenu-filter-history


### PR DESCRIPTION
Hi rougier,

First of all, thanks for your wonderful work. I've been following in quite a few projects and i love it. Here is an already on [reddit](https://www.reddit.com/r/emacs/comments/y78jh5/symbols_definition_is_void_orgmaketagmatcher/) discussed issue which hasn't been resolved on this configuration yet.

regards,
Alessandro