### PR TITLE
fix: funcall: Symbol’s function definition is void: cape-symbol

### DIFF
--- a/dotemacs.org
+++ b/dotemacs.org
@@ -1949,7 +1949,7 @@ A few more useful configurations...
 ;; Completion in source blocks
 (require 'cape)
 
-(add-to-list 'completion-at-point-functions 'cape-symbol)
+(add-to-list 'completion-at-point-functions 'cape-elisp-symbol)
 
 #+end_src
 


### PR DESCRIPTION
cape-symbol has been renamed to cape-elisp-symbol, see: https://github.com/minad/cape/commit/8ce0e412931785bc96519d1bc3145300658cb00b